### PR TITLE
Debian Trixie Compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ readme = 'README.rst'
 requires-python = '>=3.7'
 dependencies = [
 	'appdirs >= 1.4.3, < 2.0.0',
-	'pyparsing >= 2.2.0, < 3.0.0',
+	'pyparsing >= 2.2.0, <3.2.0',
 	'packaging >= 16.8',
-	'pyOpenSSL >= 17.5.0, < 20.0.0',
+	'pyOpenSSL >= 17.5.0',
 	'py3dns >= 3.1.0, < 5.0.0',
-	'cryptography >= 2.1.4, < 36.0.0',
+	'cryptography >= 2.6.1',
 	'asn1crypto >= 0.24.0, < 2.0.0',
-	'acme >= 0.25.1, < 1.19.0',
+	'acme >= 2.0.0, < 4.0.0',
 	'PyYAML >= 3.1, < 7.0.0',
 	'josepy >=1.0.0, < 2.0.0',
 ]

--- a/src/acmebot/acmebot.py
+++ b/src/acmebot/acmebot.py
@@ -1705,7 +1705,7 @@ class AcmeManager:
         if (must_staple):
             extensions.append(self._ocsp_must_staple_extension())
         req.add_extensions(extensions)
-        req.set_version(2)
+        req.set_version(0)
         req.set_pubkey(private_key)
         req.sign(private_key, 'sha256')
         return OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, req)


### PR DESCRIPTION
I am currently working on packaging acmebot for Debian. You can find the project on [Salsa](https://salsa.debian.org/hinrikus/acmebot).

Please note that Debian no longer supports the old BackwardCompatibleClientV2. As a result, I have reworked PR #48 by @skofisk to align it with the current development snapshot (thank you for your contributions!).

Additionally, I had to update several dependencies and address some compatibility issues.